### PR TITLE
Add `transact-fn` optional arg to `migrate!`

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,13 +183,16 @@ transact "catch-up" migration marker entities but without the associated migrati
 The primary API of caribou is only one function: `io.recbus.caribou/migrate!`.
 
 ``` clojure
-(migrate! conn migrations & {:keys [tx-instant context claim-only?] :as options})
+(migrate! conn migrations & {:keys [tx-instant transact-fn context claim-only?] :as options})
 ```
 It is possible to omit the `context` parameter, in which case it is assumed to be an empty map (`{}`).
 
 If supplied, `tx-instant` overrides the `:db/txInstant` of the transactions that install Caribou's own schema
 and tracking entity.  It does _not_ override the `:db/txInstant` of your migrations -but that is easily accomplished
 with an appropriately reified migration transaction.
+
+If supplied, `transact-fn` will be used instead of `d/transact` for the migrations. It will also be used to install
+Caribou's own schema and tracking entity.
 
 The `claim-only?` option is used to inject Caribou migration records without actually transacting the associated `tx-data`.
 

--- a/deps.edn
+++ b/deps.edn
@@ -28,6 +28,7 @@
                                 org.clojure/data.csv                {:mvn/version "1.1.0"}}
                   :jvm-opts    ["-XX:-OmitStackTraceInFastThrow"]}
 
+           ;; Example Usage: clj -M:test:test-runner
            :test-runner {:extra-deps {com.cognitect/test-runner      {:git/url "https://github.com/cognitect-labs/test-runner.git"
                                                                       :git/sha "dfb30dd"
                                                                       :git/tag "v0.5.1"}

--- a/test-resources/migrations.edn
+++ b/test-resources/migrations.edn
@@ -71,7 +71,7 @@
                                       :tx-data-fn   st.migrations.ansi-states/tx-data,
                                       :context
                                       {:data
-                                       #st/url "file:/Users/cch1/Development/SunTribe/st/resources/migrations/stt/seeds/ansi/state.txt"},
+                                       #st/url "file:test-resources/migrations/seeds/ansi/state.txt"},
                                       :dependencies [:st.schema/tx-metadata :st.schema/ansi-states]},
  :st.schema/ansi-counties            {:tx-data
                                       [{:db/id "datomic.tx", :st.db/provenance "Schema Migration"}
@@ -127,7 +127,7 @@
                                       :tx-data-fn st.migrations.ansi-counties/tx-data,
                                       :context
                                       {:data
-                                       #st/url "file:/Users/cch1/Development/SunTribe/st/resources/migrations/stt/seeds/ansi/national_county.txt"},
+                                       #st/url "file:test-resources/migrations/seeds/ansi/national_county.txt"},
                                       :dependencies
                                       [:st.schema/tx-metadata
                                        :st.seeds/ansi-states
@@ -256,7 +256,7 @@
                                       st.migrations.pjm-utilities/balancing-authorities-tx-data,
                                       :context
                                       {:data
-                                       #st/url "file:/Users/cch1/Development/SunTribe/st/resources/migrations/stt/seeds/pjm/Utilities_20230323_133352.csv"},
+                                       #st/url "file:test-resources/migrations/seeds/pjm/Utilities_20230323_133352.csv"},
                                       :dependencies [:st.schema/pjm-utilities :st.seeds/ansi-counties]}
  :st.seeds/pjm-utilities             {:tx-data
                                       [{:db/id            "datomic.tx",
@@ -265,7 +265,7 @@
                                       :tx-data-fn   st.migrations.pjm-utilities/utilities-tx-data,
                                       :context
                                       {:data
-                                       #st/url "file:/Users/cch1/Development/SunTribe/st/resources/migrations/stt/seeds/pjm/Utilities_20230323_133352.csv"},
+                                       #st/url "file:test-resources/migrations/seeds/pjm/Utilities_20230323_133352.csv"},
                                       :dependencies [:st.schema/pjm-utilities]}
  :st.seeds/pjm-cubs                  {:tx-data
                                       [{:db/id            "datomic.tx",
@@ -274,7 +274,7 @@
                                       :tx-data-fn st.migrations.pjm-utilities/cubs-tx-data,
                                       :context
                                       {:data
-                                       #st/url "file:/Users/cch1/Development/SunTribe/st/resources/migrations/stt/seeds/pjm/Utilities_20230323_133352.csv"},
+                                       #st/url "file:test-resources/migrations/seeds/pjm/Utilities_20230323_133352.csv"},
                                       :dependencies
                                       [:st.schema/pjm-utilities
                                        :st.seeds/pjm-utilities


### PR DESCRIPTION
If supplied, `transact-fn` will be used instead of `d/transact` for the migrations.

Also includes a commit to make tests pass by using relative paths to seed files.